### PR TITLE
fix: syntax format in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-@open-sauced/triage
-@open-sauced/community
+* @open-sauced/community


### PR DESCRIPTION
## Description

Currently, we have CODEOWNERS file that contains the list of code owners. But they don't get added automatically as reviewers as it suppposed to. And it happens because the syntax has to be on the same line.

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] ☝️ Add a pizza fact or trivia
- [ ] 🧑‍🍳 Add a pizza recipe
- [ ] 🗺️ Add a regional pizza
- [x] 📝 Documentation Update

## Related Tickets & Documents

Fixes #74 

<!--
Please use this format link issue numbers: Fixes/Relates to #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Added to documentation?

- [ ] 📜 README.md
- [x] 🙅 no documentation needed

## [optional] What GIF best describes this PR or how it makes you feel?

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
